### PR TITLE
feat: add thresholds and responsive gauge

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,11 @@ interface Style {
   dynamicStyleConfig?: DynamicStyleConfig
 }
 
+export interface Threshold {
+  value: number
+  color: string
+}
+
 export interface Config {
   /**
    * Note: The placeholder must be a nested structure of tags with the text inside:
@@ -28,6 +33,7 @@ export interface Config {
   speedometerTickFont?: string
   speedometerTickSize?: number
   speedometerPadding?: number
+  speedometerThresholds?: Threshold[]
 }
 
 export type IMConfig = ImmutableObject<Config>

--- a/src/runtime/builder/editor.tsx
+++ b/src/runtime/builder/editor.tsx
@@ -72,7 +72,7 @@ export const Editor = (props: EditorProps): React.ReactElement => {
   const plugin = usePlugin(widgetId, useDataSources, enabled, onInitResizeHandler)
   const style = useStyle(text, useDataSources)
   const handleComplete = (value: string, placeholder: string) => {
-    const newValue = appConfigUtils.restoreResourceUrl(value)
+    const newValue = typeof appConfigUtils?.restoreResourceUrl === 'function' ? appConfigUtils.restoreResourceUrl(value) : value
     onComplete?.(newValue, placeholder)
   }
 

--- a/src/runtime/builder/plugins.tsx
+++ b/src/runtime/builder/plugins.tsx
@@ -13,8 +13,13 @@ interface _TextPluginsProps {
 
 type TextPluginsProps = _TextPluginsProps & RichPluginRequiredProps
 
-const ARCADE_CONTENT_CAPABILITIES = [ArcadeContentCapability.Value, ArcadeContentCapability.Style]
-const DYNAMIC_STYLE_TYPES = Immutable([DynamicStyleType.Text])
+const ARCADE_CONTENT_CAPABILITIES = typeof ArcadeContentCapability !== 'undefined'
+  ? [ArcadeContentCapability.Value, ArcadeContentCapability.Style]
+  : []
+
+const DYNAMIC_STYLE_TYPES = typeof DynamicStyleType !== 'undefined'
+  ? Immutable([DynamicStyleType.Text])
+  : Immutable([])
 
 export const TextPlugins = (props: TextPluginsProps): React.ReactElement => {
   const { editor, formats, selection, useDataSources, widgetId, enabled, onInitResizeHandler } = props

--- a/src/runtime/displayer.tsx
+++ b/src/runtime/displayer.tsx
@@ -3,6 +3,7 @@ import { DownDoubleOutlined } from 'jimu-icons/outlined/directional/down-double'
 import { styled, useTheme } from 'jimu-theme'
 import { RichTextDisplayer, type RichTextDisplayerProps, Scrollable, type ScrollableRefProps, type StyleSettings, type StyleState, styleUtils } from 'jimu-ui'
 import { Speedometer } from './speedometer'
+import type { Threshold } from '../config'
 
 const LeaveDelay = 500
 
@@ -22,6 +23,7 @@ export type DisplayerProps = Omit<RichTextDisplayerProps, 'sanitize'> & {
   speedometerTickFont?: string
   speedometerTickSize?: number
   speedometerPadding?: number
+  speedometerThresholds?: Threshold[]
 }
 
 const Root = styled('div')<StyleState<{ wrap: boolean, fadeLength: string }>>(({ theme, styleState }) => {
@@ -126,6 +128,7 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
     speedometerTickFont,
     speedometerTickSize,
     speedometerPadding,
+    speedometerThresholds,
     ...others
   } = props
 
@@ -232,10 +235,10 @@ export function Displayer(props: DisplayerProps): React.ReactElement {
             tickFontFamily={speedometerTickFont}
             tickFontSize={speedometerTickSize}
             padding={speedometerPadding}
+            thresholds={speedometerThresholds}
           />
         )}
       </Scrollable>
-      {speed !== null && <Speedometer value={speed} />}
       {showFade && scrollable && !bottoming && <div className='text-fade text-fade-bottom'>
         <span className='arrow arrow-bottom rounded-circle mr-1'>
           <DownDoubleOutlined className='bounce' color={theme?.ref.palette?.black} />

--- a/src/runtime/speedometer.tsx
+++ b/src/runtime/speedometer.tsx
@@ -1,4 +1,5 @@
-import { React } from 'jimu-core'
+/** @jsx jsx */
+import { React, jsx } from 'jimu-core'
 
 export interface SpeedometerProps {
   value: number
@@ -6,6 +7,7 @@ export interface SpeedometerProps {
   max?: number
   gaugeColor?: string
   needleColor?: string
+  thresholds?: { value: number, color: string }[]
   labelColor?: string
   labelFontFamily?: string
   labelFontSize?: number
@@ -16,66 +18,81 @@ export interface SpeedometerProps {
   padding?: number
 }
 
-export const Speedometer = ({
-  value,
-  min = 0,
-  max = 40,
-  gaugeColor = '#000',
-  needleColor = 'red',
-  labelColor = '#000',
-  labelFontFamily = 'Arial',
-  labelFontSize = 12,
-  labelBold = false,
-  tickColor = '#000',
-  tickFontFamily = 'Arial',
-  tickFontSize = 10,
-  padding = 0
-}: SpeedometerProps): React.ReactElement => {
+export function Speedometer(props: SpeedometerProps): React.ReactElement {
+  const {
+    value,
+    min = 0,
+    max = 40,
+    gaugeColor = '#000',
+    needleColor = 'red',
+    labelColor = '#000',
+    labelFontFamily = 'Arial',
+    labelFontSize = 12,
+    labelBold = false,
+    tickColor = '#000',
+    tickFontFamily = 'Arial',
+    tickFontSize = 10,
+    padding = 0,
+    thresholds
+  } = props
+
   const ratio = Math.max(0, Math.min(1, (value - min) / (max - min)))
   const angle = ratio * 180 - 90
-  const ticks = React.useMemo(() => {
-    const count = 4
-    const cx = 100
-    const cy = 100
-    const outer = 90
-    const inner = 82
-    const labelRadius = 65
-    return Array.from({ length: count + 1 }, (_, i) => {
-      const r = i / count
-      const rad = Math.PI - r * Math.PI
-      const cos = Math.cos(rad)
-      const sin = Math.sin(rad)
-      const x1 = cx + outer * cos
-      const y1 = cy - outer * sin
-      const x2 = cx + inner * cos
-      const y2 = cy - inner * sin
-      const lx = cx + labelRadius * cos
-      const ly = cy - labelRadius * sin
-      const label = Math.round(min + (max - min) * r)
-      return { x1, y1, x2, y2, lx, ly, label }
-    })
-  }, [min, max])
+
+  const sorted = thresholds ? [...thresholds].sort((a, b) => a.value - b.value) : []
+  const active = sorted.find(t => value <= t.value) || sorted[sorted.length - 1]
+  const gaugeStroke = active ? active.color : gaugeColor
+  const needleStroke = active ? active.color : needleColor
+
+  const count = 4
+  const cx = 100
+  const cy = 100
+  const outer = 90
+  const inner = 82
+  const labelRadius = 65
+  const ticks = Array.from({ length: count + 1 }, (_, i) => {
+    const r = i / count
+    const rad = Math.PI - r * Math.PI
+    const cos = Math.cos(rad)
+    const sin = Math.sin(rad)
+    return {
+      x1: cx + outer * cos,
+      y1: cy - outer * sin,
+      x2: cx + inner * cos,
+      y2: cy - inner * sin,
+      lx: cx + labelRadius * cos,
+      ly: cy - labelRadius * sin,
+      label: Math.round(min + (max - min) * r)
+    }
+  })
+
+  const needleTransform = `rotate(${angle} 100 100)`
+
   return (
-    <div className='speedometer' style={{ width: '100%', display: 'flex', justifyContent: 'center', marginTop: 8, padding }}>
-      <svg width='100%' height='100%' viewBox='0 0 200 140' xmlns='http://www.w3.org/2000/svg' aria-label='Gauge icon'>
+    <div className='speedometer' style={{ width: '100%', height: '100%', padding }}>
+      <svg
+        viewBox='0 0 200 200'
+        xmlns='http://www.w3.org/2000/svg'
+        aria-label='Gauge icon'
+        preserveAspectRatio='xMidYMid meet'
+        style={{ width: '100%', height: '100%', overflow: 'visible' }}
+      >
         <g fill='none' strokeLinecap='round'>
-          <g stroke={gaugeColor}>
-            <path d='M 10 100 A 90 90 0 0 1 190 100' strokeWidth='4' />
-            <g strokeWidth='4'>
-              {ticks.map((t, i) => (
-                <line key={i} x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2} />
-              ))}
-            </g>
-            <g strokeWidth='2'>
-              <line x1='100' y1='88' x2='100' y2='82' />
-              <line x1='112' y1='100' x2='118' y2='100' />
-              <line x1='100' y1='112' x2='100' y2='118' />
-              <line x1='88' y1='100' x2='82' y2='100' />
-              <line x1='108' y1='92' x2='112' y2='88' />
-              <line x1='108' y1='108' x2='112' y2='112' />
-              <line x1='92' y1='108' x2='88' y2='112' />
-              <line x1='92' y1='92' x2='88' y2='88' />
-            </g>
+          <path d='M 10 100 A 90 90 0 0 1 190 100' strokeWidth={4} stroke={gaugeStroke} />
+          <g strokeWidth={4} stroke={gaugeStroke}>
+            {ticks.map((t, i) => (
+              <line key={i} x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2} />
+            ))}
+          </g>
+          <g strokeWidth={2} stroke={gaugeStroke}>
+            <line x1={100} y1={88} x2={100} y2={82} />
+            <line x1={112} y1={100} x2={118} y2={100} />
+            <line x1={100} y1={112} x2={100} y2={118} />
+            <line x1={88} y1={100} x2={82} y2={100} />
+            <line x1={108} y1={92} x2={112} y2={88} />
+            <line x1={108} y1={108} x2={112} y2={112} />
+            <line x1={92} y1={108} x2={88} y2={112} />
+            <line x1={92} y1={92} x2={88} y2={88} />
           </g>
           <g stroke='none'>
             {ticks.map((t, i) => (
@@ -89,18 +106,18 @@ export const Speedometer = ({
                 fontFamily={tickFontFamily}
                 fill={tickColor}
               >
-                {t.label}
+                {t.label.toString()}
               </text>
             ))}
           </g>
-          <g stroke={needleColor} strokeWidth='3'>
-            <circle cx='100' cy='100' r='12' fill='none' />
-            <line x1='100' y1='100' x2='100' y2='50' transform={`rotate(${angle} 100 100)`} />
+          <g stroke={needleStroke} strokeWidth={3}>
+            <circle cx={100} cy={100} r={12} fill='none' />
+            <line x1={100} y1={100} x2={100} y2={50} transform={needleTransform} />
           </g>
         </g>
         <text
-          x='100'
-          y='135'
+          x={100}
+          y={170}
           textAnchor='middle'
           fontSize={labelFontSize}
           fontFamily={labelFontFamily}

--- a/src/runtime/widget.tsx
+++ b/src/runtime/widget.tsx
@@ -89,7 +89,10 @@ const Widget = (props: AllWidgetProps<IMConfig>): React.ReactElement => {
 
   const wrap = config.style?.wrap ?? true
   const color = config.style?.color
-  const text = React.useMemo(() => appConfigUtils.processResourceUrl(config.text), [config.text])
+  const text = React.useMemo(
+    () => (typeof appConfigUtils?.processResourceUrl === 'function' ? appConfigUtils.processResourceUrl(config.text) : config.text),
+    [config.text]
+  )
   const tooltip = config.tooltip
   const placeholder = translatePlaceholder(config.placeholder, intl)
   const useDataSources = useDataSourcesEnabled ? propUseDataSources : undefined
@@ -337,6 +340,7 @@ const Widget = (props: AllWidgetProps<IMConfig>): React.ReactElement => {
         speedometerTickFont={config.speedometerTickFont}
         speedometerTickSize={config.speedometerTickSize}
         speedometerPadding={config.speedometerPadding}
+        speedometerThresholds={config.speedometerThresholds}
       />
       <Popper open={isDynamicStyleSettingActive} offsetOptions={[0, 4]} css={getDynamicPreviewStyle()} autoUpdate shiftOptions={shiftOptions}
         flipOptions={flipOptions} placement='right-start' reference={rootRef} >

--- a/src/setting/setting.tsx
+++ b/src/setting/setting.tsx
@@ -57,18 +57,31 @@ const Setting = (props: SettingProps): React.ReactElement => {
   const textBold = propConfig.speedometerTextBold ?? false
   const textColor = propConfig.speedometerTextColor ?? '#000'
   const padding = propConfig.speedometerPadding ?? 0
+  const thresholds = propConfig.speedometerThresholds ?? [
+    { value: 1, color: '#ff0000' },
+    { value: 2, color: '#ffff00' },
+    { value: 3, color: '#00ff00' }
+  ]
 
   const [localFont, setLocalFont] = React.useState(textFont)
   const [localSize, setLocalSize] = React.useState(String(textSize))
   const [localTickFont, setLocalTickFont] = React.useState(tickFont)
   const [localTickSize, setLocalTickSize] = React.useState(String(tickSize))
   const [localPadding, setLocalPadding] = React.useState(String(padding))
+  const [localThreshold1, setLocalThreshold1] = React.useState(String(thresholds[0].value))
+  const [localThreshold2, setLocalThreshold2] = React.useState(String(thresholds[1].value))
+  const [localThreshold3, setLocalThreshold3] = React.useState(String(thresholds[2].value))
 
   React.useEffect(() => { setLocalFont(textFont) }, [textFont])
   React.useEffect(() => { setLocalSize(String(textSize)) }, [textSize])
   React.useEffect(() => { setLocalTickFont(tickFont) }, [tickFont])
   React.useEffect(() => { setLocalTickSize(String(tickSize)) }, [tickSize])
   React.useEffect(() => { setLocalPadding(String(padding)) }, [padding])
+  React.useEffect(() => {
+    setLocalThreshold1(String(thresholds[0].value))
+    setLocalThreshold2(String(thresholds[1].value))
+    setLocalThreshold3(String(thresholds[2].value))
+  }, [thresholds])
   const enableDynamicStyle = style?.enableDynamicStyle ?? false
   const dynamicStyleConfig = style?.dynamicStyleConfig
   const text = propConfig.text
@@ -186,6 +199,30 @@ const Setting = (props: SettingProps): React.ReactElement => {
     })
   }
 
+  const handleThresholdValueAccept = (index: number, value: number | string): void => {
+    const num = typeof value === 'number' ? value : parseInt(value)
+    if (!isNaN(num)) {
+      index === 0 && setLocalThreshold1(String(num))
+      index === 1 && setLocalThreshold2(String(num))
+      index === 2 && setLocalThreshold3(String(num))
+      const arr = [...thresholds]
+      arr[index] = { ...arr[index], value: num }
+      onSettingChange({
+        id,
+        config: propConfig.set('speedometerThresholds', arr)
+      })
+    }
+  }
+
+  const handleThresholdColorChange = (index: number, color: string): void => {
+    const arr = [...thresholds]
+    arr[index] = { ...arr[index], color }
+    onSettingChange({
+      id,
+      config: propConfig.set('speedometerThresholds', arr)
+    })
+  }
+
   const handlePaddingAccept = (value: number | string): void => {
     const num = typeof value === 'number' ? value : parseInt(value)
     if (!isNaN(num)) {
@@ -266,7 +303,9 @@ const Setting = (props: SettingProps): React.ReactElement => {
   const handleTextChange = (html: string, key?: RichTextFormatKeys, value?: any): void => {
     const onlyPlaceholder = richTextUtils.isBlankRichText(text) && !!placeholder
     const property = !isInlineEditing && onlyPlaceholder ? 'placeholder' : 'text'
-    html = property === 'text' ? appConfigUtils.restoreResourceUrl(html) : html
+    html = property === 'text' && typeof appConfigUtils?.restoreResourceUrl === 'function'
+      ? appConfigUtils.restoreResourceUrl(html)
+      : html
     let config = propConfig.set(property, html)
     if (!isInlineEditing && key === RichTextFormatKeys.Color) {
       config = config.setIn(['style', 'color'], value)
@@ -359,6 +398,18 @@ const Setting = (props: SettingProps): React.ReactElement => {
           </SettingRow>
           <SettingRow className='mb-3' flow='no-wrap' label={translate('gaugePadding')}>
             <TextInput style={{ width: 80 }} type='number' value={localPadding} onChange={(_e, v) => setLocalPadding(v)} onAcceptValue={handlePaddingAccept} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('threshold1')}>
+            <TextInput style={{ width: 80 }} type='number' value={localThreshold1} onChange={(_e, v) => setLocalThreshold1(v)} onAcceptValue={(v) => handleThresholdValueAccept(0, v)} />
+            <ThemeColorPicker className='ml-2' value={thresholds[0].color} onChange={color => handleThresholdColorChange(0, color)} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('threshold2')}>
+            <TextInput style={{ width: 80 }} type='number' value={localThreshold2} onChange={(_e, v) => setLocalThreshold2(v)} onAcceptValue={(v) => handleThresholdValueAccept(1, v)} />
+            <ThemeColorPicker className='ml-2' value={thresholds[1].color} onChange={color => handleThresholdColorChange(1, color)} />
+          </SettingRow>
+          <SettingRow className='mb-3' flow='no-wrap' label={translate('threshold3')}>
+            <TextInput style={{ width: 80 }} type='number' value={localThreshold3} onChange={(_e, v) => setLocalThreshold3(v)} onAcceptValue={(v) => handleThresholdValueAccept(2, v)} />
+            <ThemeColorPicker className='ml-2' value={thresholds[2].color} onChange={color => handleThresholdColorChange(2, color)} />
           </SettingRow>
           <SettingRow className='mb-3' flow='no-wrap' tag='label' label={translate('textBold')}>
             <Switch checked={textBold} onChange={toggleTextBold} />

--- a/src/setting/translations/default.ts
+++ b/src/setting/translations/default.ts
@@ -11,5 +11,8 @@ export default {
   textFont: 'Value font',
   textSize: 'Value size',
   textBold: 'Value bold',
-  gaugePadding: 'Gauge padding'
+  gaugePadding: 'Gauge padding',
+  threshold1: 'Threshold 1',
+  threshold2: 'Threshold 2',
+  threshold3: 'Threshold 3'
 }


### PR DESCRIPTION
## Summary
- make speedometer gauge maintain aspect ratio to avoid clipping
- add configurable color thresholds and apply them based on value
- compute thresholds and ticks without `useMemo` to avoid module parse errors
- declare Speedometer as a function component to resolve bundler parse error
- render speedometer with JSX to eliminate remaining module parse failures
- color gauge arc and needle using the active threshold's color
- guard optional ArcadeContentCapability and DynamicStyleType to prevent builder crash when these exports are missing
- guard appConfigUtils resource helpers so widget loads even when `processResourceUrl` or `restoreResourceUrl` are absent

## Testing
- `npx tsc src/runtime/widget.tsx --jsx react --esModuleInterop --target es2015 --module commonjs --skipLibCheck` *(fails: Cannot find module 'jimu-core')*
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0ed4fd548330b500dac6add6a9a1